### PR TITLE
correct origin cors middleware

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -15,7 +15,7 @@ const port = process.env.PORT || 3000;
 app.use(express.json());
 app.use(cookieParser());
 const allowlist = [
-  "http://localhost:3000",
+  "http://localhost:5173",
   "https://posts-seven-red.vercel.app",
 ];
 


### PR DESCRIPTION
correct port

## Summary by Sourcery

Bug Fixes:
- Correct local origin in CORS middleware to use port 5173 instead of 3000